### PR TITLE
feat: ability to create webhooks

### DIFF
--- a/src/config/config.mts
+++ b/src/config/config.mts
@@ -28,6 +28,9 @@ export const createConfig = (env: Env) => ({
         appId: 353840,
         privateKey: env.GH_APP_PRIVATE_KEY || '',
       },
+      webhooks: {
+        secret: env.GH_APP_SECRET_TOKEN || '',
+      },
     },
     actions: {},
   },


### PR DESCRIPTION
#### Changes

- Ability to create webhooks

Edit: this is actually no longer needed because listening to events can be done as part of the permissions scheme. Which seems to be working well.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
